### PR TITLE
Document changes of dev/base-flask-server.

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -2,7 +2,9 @@
 
 ## Compiling the Client ##
 
-First the client needs to be compiled. For this enter to the `client/` directory and execute `npm install` to locally install all the required dependencies. After that executing `npm run build` should build the client:
+First the client needs to be compiled. For this enter to the `client/`
+directory and execute `npm install` to locally install all the required
+dependencies. After that executing `npm run build` should build the client:
 
 ```sh
 cd client/
@@ -10,23 +12,39 @@ npm install
 npm run build
 ```
 
-While working on the client this edit-compile-run cycle can get a bit slow (webpack isn't the fastest while compiling typescript). To address this issue a "dev server" is provided that automatically detect any change in the source, compilet it and then place the compiled client into `diogenet_py/static/bundle.js`. To run this dev server the following command must be used instead of `npm build`:
+While working on the client this edit-compile-run cycle can get a bit slow
+(webpack isn't the fastest while compiling typescript). To address this issue
+a "dev server" is provided that automatically detect any change in the
+source, compilet it and then place the compiled client into
+`diogenet_py/static/client/`. To run this dev server the following command
+must be used instead of `npm build`:
 
 ```sh
 npm run start
 ```
 
-Compiling the client will create the compiled source and a sourcemap in the `diogenet_py/static/bundle.js` and `diogenet_py/static/bundle.js.map** files respectively. Now that they are compiled the Flash application can make use of them.
+Compiling the client will put all the compiled resources (with their respective
+sourcemap) in the `diogenet_py/static/client` directory. All resources,
+including SASS/SCSS and dependencies of the program (like images or icons)
+will also go to that directory. Now that they are compiled the Flash
+application can make use of them.
 
-**Note**: It is required to build the client before using the `diogenet_py` package. Once the server is built, it does not need to be rebuilt when changes are made only over `diogenet_py`.
+**Note**: It is required to build the client before using the `diogenet_py`
+package. Once the server is built, it does not need to be rebuilt when changes
+are made only over `diogenet_py`.
 
 ## Installing the Python Package ##
 
-The python package itself does not needs to be compiled, but to run it outside of the toplevel directory it needs to be installed.
+The python package itself does not needs to be compiled, but to run it outside
+of the toplevel directory it needs to be installed.
 
 ### Creating a Virtual Environment ###
 
-For safety reasons a virtual environment is recommended to be used. If virtualenvwrapper is being used then the following command should create a virtual environment with the name `diogenet_py`. That specific name is not required but if you use a different one remember to change it throught the rest of the installation instructions:
+For safety reasons a virtual environment is recommended to be used. If
+virtualenvwrapper is being used then the following command should create a
+virtual environment with the name `diogenet_py`. That specific name is not
+required but if you use a different one remember to change it throught the rest
+of the installation instructions:
 
 ```sh
 mkvirtualenv diogenet_py
@@ -76,7 +94,9 @@ reinstall).
 
 #### Installing for production ####
 
-The application can be packaged as described in the next section.  That will automatically install the package and its dependencies as a `whl` file, under `dist/`, and in the current virtual environment. 
+The application can be packaged as described in the next section.  That will
+automatically install the package and its dependencies as a `whl` file, under
+`dist/`, and in the current virtual environment.
 
 ### Packaging ###
 

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -18,9 +18,8 @@ installing). This package has two special directories in it: `static/` and
 `templates/` contains the Jinja templates.
 
 There is an special file in `diogenet_py/static/`: When the client is compiled
-(see [`COMPILING.md`](COMPILING.md)) two files named `bundle.js` and
-`bundle.js.map` are put into `diogenet_py/static/`. Those files are the compiled
-source for the client and the sourcemap of it.
+(see [`COMPILING.md`](COMPILING.md)) a directory `client/` inside
+`diogenet_py/static/` will contain all the compiled resources.
 
 ## The Documentation ##
 
@@ -39,9 +38,15 @@ under `tests/` which filename starts with `test_` is a test.
 
 ## The Client ##
 
-The `client/` directory contains the source for the javascript client, it has
-a very simple structure consisting only of a `src/` subdirectory with the
-TypeScript source of the client, and a few configuration files for the different
-linters and compilers. In particular, ESLint with the TypeScript plugin is used
-as a linter and Babel+Webpack are used to compile and bundle the source code to
-a single file.
+The `client/` directory contains the source for the Javascript client. It has
+a very simple structure:
+
+- `src/` contains the typescript/javascript sources. Generally one main file
+  per page (so `map.ts` for the map page and `horus.ts` for the horus).
+- `styles/` contains any SASS/SCSS to be compiled.
+
+Typescript is compiled to Javascript which is later passed to Babel. The
+SASS/SCSS files are compiled too via a dummy `styles.ts` file that imports
+them. All of the compiled files are then bundled with Webpack and the
+compiled output (plus any additional sourcemap) is put into
+`diogenet_py/static/client/` where the server can load it.


### PR DESCRIPTION
The branch dev/base-flask-server made some changes (notably to the client) that affected where some files are and what they do (most importantly, things like stylesheets are now into an `styles/` directory and a `client/` directory inside `static/` instead of a single `bundle.js` file). These changes were undocumented.